### PR TITLE
Reduced image size (629MB - 572MB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
     cmake \
+    flex \
     libdumbnet-dev \
     libhwloc-dev \
+    libflatbuffers-dev \
     libgoogle-perftools-dev \
     libhyperscan-dev \
     libluajit-5.1-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:rolling
-MAINTAINER Michael Altizer <mialtize@cisco.com>
+LABEL maintainer="Michael Altizer <mialtize@cisco.com>"
 
 # Workaround for headless installation hang during Docker build
 ARG DEBIAN_FRONTEND=noninteractive
@@ -9,11 +9,13 @@ RUN \
 apt-get update && \
 apt-get dist-upgrade -y && \
 # Install the Snort build dependencies
-apt-get install -y \
+apt-get install -y --no-install-recommends \
     build-essential \
+    ca-certificates \
     cmake \
     libdumbnet-dev \
     libhwloc-dev \
+    libgoogle-perftools-dev \
     libhyperscan-dev \
     libluajit-5.1-dev \
     liblzma-dev \
@@ -21,6 +23,7 @@ apt-get install -y \
     libpcap-dev \
     libpcre3-dev \
     libssl-dev \
+    libtool \
     libunwind-dev \
     pkg-config \
     uuid-dev \
@@ -35,4 +38,5 @@ apt-get install -y \
 #     asciidoc dblatex w3m \
 && \
 # Clean out the APT cache
-apt-get clean
+apt-get clean \
+&& rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ cd libdaq
 ./bootstrap
 ./configure
 make install
+cd /usr/local/lib/daq/
 ldconfig
 
 cd $HOME


### PR DESCRIPTION
  - Removed recommended packages
    - explicitely install libtool, ca-certificates
  - Added libgoogle-perftools-dev (--enable-tcmalloc)
  - removed apt cache (rm -rf /var/lib/apt/lists/*)